### PR TITLE
Fix javascript travis example

### DIFF
--- a/docs/_posts/0000-02-04-ci-exercise.md
+++ b/docs/_posts/0000-02-04-ci-exercise.md
@@ -49,7 +49,7 @@ script:
 
 ```yaml
 language: node_js
-before_script: "cd exercises/javascript"
+before_install: "cd exercises/javascript"
 node_js:
   - 10
 ```


### PR DESCRIPTION
cd to relevant directory needs to happen before install not scripts so npm ci  can find package.json